### PR TITLE
Documented change: ```Calibration measurement``` may use a relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,12 +300,17 @@ properties:
 
 #### Create skeleton (Introduced in QTM 2021.2)
 This analysis creates skeletons for the specified file provided that the correct marker names and prefixes are used (see the marker set guides in QTM > Skeleton for more information). It has the followng properties:
-- **Calibration measurement:** Required. A string to specify the file name to create the skeletons. Wildcard can be used in the name to avoid specifying the whole name. If multiple files are detected, the first measurement that matches the specified file name will be used.  Only measurements that are marked as used in the PAF pane will be affected.
-> Note: Frame number that is used to create the skeletons is set to the middle of the selected range.
+- **Calibration measurement:** Required. A string to specify the file name to create the skeletons. Wildcard can be used in the name to avoid specifying the whole name. If multiple files are detected, the first measurement that matches the specified file name will be used. 
+
+    Relative paths may be used for sharing the same calibration measurements between subsessions. 
+    Example: ```Calibration measurement: ..\Static\Static*```
+
+    > Note: Frame number that is used to create the skeletons is set to the middle of the selected range.
+
 
 #### Solve skeleton (Introduced in QTM 2021.2)
 This analysis solves skeletons for the specified files provided that the skeletons already exist  and that the correct marker names and prefixes are used (see the marker set guides in QTM > Skeleton for more information). It has the following properties:
-- **Measurements:** Required. A string or list of strings to specify the file names to solve the skeletons. Wildcard can be used in the name to specify multiple files at once. To specify all measurements, simply use the wildcard character.  Only measurements that are marked as used in the PAF pane will be affected.
+- **Measurements:** Required. A string or list of strings to specify the file names to solve the skeletons. Wildcard can be used in the name to specify multiple files at once. To specify all measurements, simply use the wildcard character. Only measurements that are marked as used in the PAF pane will be affected.
 - **Exclude:** Optional. A string or list of strings to specify the file names to exclude. Wildcard can be used in the name to specify multiple files at once.  Only measurements that are marked as used in the PAF pane will be affected.
 
 Example 1:


### PR DESCRIPTION
In order to enable sharing of static analysis between sub-sessions. The field ``Calibration measurement`` in ``Create skeleton`` Has been updated with the following changes.
- Allow for finding and using a measurement in a relative directory.
- Allow for finding and using a measurement which does not carry the ``used flag``