### PR TITLE
Changes to support parent session level analyses

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,16 +219,13 @@ Each analysis definition is a map that has some properties common to all analysi
     - ``..`` Parent dir 
     -  ``*`` Wild card file or directory name. Using ``**`` to traverse multiple levels of subfolders is not supported.
 
-    Default:
+    Default:    
 
     If the Measurements field has not been defined it's set to the default value: ``'*.qtm' ``
 
     Example:
     ```
-    Measurements: 
-      - '*.qtm'
-      - "..\\Folder\\SubFolder*\\*File.qtm"
-      - '*\*'
+    Measurements: ['*.qtm', "..\\Folder\\SubFolder*\\*File.qtm", '*\*']
     ```
 
 #### External program

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ properties:
 
 #### Create skeleton (Introduced in QTM 2021.2)
 This analysis creates skeletons for the specified file provided that the correct marker names and prefixes are used (see the marker set guides in QTM > Skeleton for more information). It has the followng properties:
-- **Measurements:** Required. A string to specify the file name used to create the skeletons. Wildcard can be used in the name to avoid specifying the whole name. If multiple files are detected, the first measurement that matches the specified file name will be used. 
+- **Measurements:** Specifies the file to use for creating the skeletons. If multiple files are detected, only one is used.
 
     Relative paths may be used for sharing the same calibration measurements between subsessions. 
     Example: ```Measurements: ..\Static\Static*```
@@ -391,7 +391,7 @@ Example 1:
 ```
   Create skeletons:   
     Type: Create skeleton
-    Calibration measurement: 'Static*'
+    Measurements: 'Static*'
   Solve skeletons:
     Type: Solve skeleton
     Measurements: '*' 
@@ -405,7 +405,7 @@ Example 2 (using Compound to combine both types):
     Components: [Create skeletons, Solve skeletons]
   Create skeletons:
     Type: Create skeleton
-    Calibration measurement: 'Static*'
+    Measurements: 'Static*'
   Solve skeletons:
     Type: Solve skeleton
     Measurements: 'Running*'

--- a/README.md
+++ b/README.md
@@ -116,6 +116,51 @@ PAF type definitions are organized into classes. Classes are currently not used 
 
 When type name references are required in the PAF file, two forms are applicable. Either a class name can be given, which will include all types of that class or a ClassName.TypeName form can be used to reference a single type only.
 
+## Analysis Modes
+An analysis is one or a series of operations which uses QTM to generate output data. It can use QTM measurements in the data tree to do calculations and export files. Exactly what the analysis does and which files it uses is defined in the PAF YAML file. See [Overview of analyses](#overview-of-analyses) for more information about analyses.
+
+Two modes of execution of analyses are supported, these are defined by their relation to their measurement files. 
+
+1. ``Session level analysis``
+    In this mode measurement files are placed directly under the folder the analysis.
+
+2. ``Parent sessions level analysis``
+    In this mode the analsysis is executed on a folder that does not directly contain measurement files. Instead it contains Subsession folders, which in turn contain the measurement files.
+    This is useful when you need to create bulk analyses on a large amount of files.
+
+These modes also affects if certain analyses and analysis features are a available. This is described per- analysis.
+
+Selecting which mode to use is done by creating the session structure in the PAF YAML file. 
+
+Decide if you need.
+   - Session -> Measurement (``Session level analysis``)
+   - Session -> Subsession -> Measurement (``Parent sessions level analysis``)
+
+Example:
+```
+Types:
+  Subject:
+    ...
+  Date:
+    ...
+  Session:
+    # Since Functional Assessment Session contains analyses and
+    # no measurements the analyses will execute in
+    # Parent sessions level mode
+    Functional Assessment Session:
+      ...
+      Children: [Functional Assessment Subsessions]
+      Analyses: [Solve skeletons, Test analysis]
+
+    # Since Running Session contains analyses and
+    # measurements the analyses will execute in
+    # Session level analysis
+    Running Session:
+      ...
+      Measurements: [Static trial (running), Running trial]
+      Analyses: [Label and solve skeletons, Solve skeletons, Test analysis]
+```
+
 ## File sections
 The PAF file is of the YAML map form. Different keys denote the different sections of the file.
 
@@ -333,13 +378,14 @@ properties:
 
 #### Create skeleton (Introduced in QTM 2021.2)
 This analysis creates skeletons for the specified file provided that the correct marker names and prefixes are used (see the marker set guides in QTM > Skeleton for more information). It has the followng properties:
-- **Calibration measurement:** Required. A string to specify the file name to create the skeletons. Wildcard can be used in the name to avoid specifying the whole name. If multiple files are detected, the first measurement that matches the specified file name will be used. 
+- **Measurements:** Required. A string to specify the file name used to create the skeletons. Wildcard can be used in the name to avoid specifying the whole name. If multiple files are detected, the first measurement that matches the specified file name will be used. 
 
     Relative paths may be used for sharing the same calibration measurements between subsessions. 
-    Example: ```Calibration measurement: ..\Static\Static*```
+    Example: ```Measurements: ..\Static\Static*```
 
     > Note: Frame number that is used to create the skeletons is set to the middle of the selected range.
-
+    
+    See [Overview of analyses](#overview-of-analyses) For general information about ``Measurements``
 
 #### Solve skeleton (Introduced in QTM 2021.2)
 This analysis solves skeletons for the specified files provided that the skeletons already exist  and that the correct marker names and prefixes are used (see the marker set guides in QTM > Skeleton for more information). It has the following properties:

--- a/README.md
+++ b/README.md
@@ -119,14 +119,14 @@ When type name references are required in the PAF file, two forms are applicable
 ## Analysis Modes
 An analysis is one or more operations which uses QTM to generate output data. It can use QTM measurements in the data tree to do calculations and export files. Exactly what the analysis does and which files it uses is defined in the PAF YAML file. See [Overview of analyses](#overview-of-analyses) for more information about analyses.
 
-Two modes of execution of analyses are supported, these are defined by their relation to their measurement files. 
+Two modes of execution of analyses are supported, these are defined by their relation to their measurement files.
 
-1. ``Session level analysis``
+1. ``Session mode``
     In this mode measurement files are placed directly under the folder the analysis.
 
-2. ``Parent sessions level analysis``
-    In this mode the analysis is executed on a folder that does not directly contain measurement files. Instead it contains Subsession folders, which in turn contain the measurement files.
-    This is useful when you need to create bulk analyses on a large amount of files.
+2. ``Parent sessions mode``
+    In this mode the analysis is executed on a folder that does not directly contain measurement files. Instead it contains only folders, which in turn can contain additional folders or measurement files.
+    This is useful when you need to create bulk analyses on select portions of the data tree.
 
 These modes determine if certain analyses and analysis features are a available. This is described per- analysis.
 
@@ -141,16 +141,16 @@ Types:
     ...
   Session:
     # Since Functional Assessment Session contains analyses and
-    # no measurements the analyses will execute in
-    # Parent sessions level mode
+    # no measurements.
+    # Analyses are executed in Parent mode
     Functional Assessment Session:
       ...
       Children: [Functional Assessment Subsessions]
       Analyses: [Solve skeletons, Test analysis]
 
     # Since Running Session contains analyses and
-    # measurements the analyses will execute in
-    # Session level analysis
+    # measurements.
+    # Analyses are executed in Session mode
     Running Session:
       ...
       Measurements: [Static trial (running), Running trial]
@@ -246,19 +246,19 @@ Each analysis definition is a map that has some properties common to all analysi
 >Note: only External program and Compound are available to all users. Other types require the Project Automation Framework developer license which is used for internal Qualisys development and by development partners.
 >
 - **Prerequisites**: A sequence of measurement type names and analysis names that has to be completed before this analysis can be run. Measurement types are considered complete for the current session when the user has made at least the number of measurements given by that measurement type’s Minimum count field. Analyses are considered complete when the file denoted by the Output file field exists.
-> Note: Prerequisites can't be used when executing parent session level analyses.
+> Note: Prerequisites can't be used when executing analyses in parent session mode.
 - **Output file**: The name of a file that is created when this analysis is run. QTM uses this to check if the analysis has been completed. It is also used to issue a warning if this file has been changed since the analysis was last run for the current session. This property can contain patterns.
 
-- **Exclude:** Optional. A string or list of strings to specify the file names to exclude. The string patterns available are the same as for the ``Measurements`` field.
+- **Exclude**: Optional. A string or list of strings to specify the file names to exclude. The string patterns available are the same as for the ``Measurements`` field.
 
   Default:
 
   If the exclude field has not been defined no extra exclusions will be applied.
 
-- **Measurements:** Optional. A list of strings which specify the measurement files to use. Only measurements that are marked as used in the PAF pane are affected. Measurements found by the ``Exclude`` filter are also not used. It's specified per analysis if the ``Measurements`` field is utilized for that particular analysis. 
+- **Measurements**: Optional. A list of strings which specify the measurement files to use. Only measurements that are marked as used in the PAF pane are affected. Measurements found by the ``Exclude`` filter are also not used. It's specified per analysis if the ``Measurements`` field is utilized for that particular analysis. 
     Accepts special characters patterns such as
     - ``..`` Parent dir 
-    -  ``*`` Wild card file or directory name. Using ``**`` to traverse multiple levels of subfolders is not supported.
+    - ``*`` Wild card file or directory name (``**`` is not supported).
 
     Default:    
 
@@ -275,7 +275,7 @@ This analysis runs an arbitrary external program supplying a command line define
 It has the following properties:
 -  **Program display name**: Required. The name to be displayed in the directories tab in project options where the user will have to locate the external executable. NB: Because this path varies between computers rather than between projects, it is not stored in the project, but in computer-global settings file. Several analyses in different projects may share the same Program display name and QTM will automatically use the same executable path for all of them.
 - **Export session**: Optional. If present, the metadata of the session, all its ancestors and the measurements are exported into a file called session.xml.
-> Note: Export session can't be used when executing parent session level analyses.
+> Note: Export session can't be used when executing analyses in parent session mode.
 - **Export measurements**: Optional. A single string or an array containing any combination of the following values: “TSV”, “C3D”, “MAT”. Will make QTM export all the selected measurements to the corresponding formats before running the external program. Use “xml settings” to export a file with measurement settings (e.g. capture start time and analog channel names). The file will be named [file
 name].settings.xml.
 - **Template files**: Optional. A single string or an array containing names of files in the template directory. Each file will be run through the PHP engine and the result written to a file with the same name in the session directory. Standard Windows wildcards are supported, but note that if the asterisk is used to match a part of the filename, the pattern must be enclosed in single quotation marks to make sure it is not parsed as a YAML alias.
@@ -283,8 +283,8 @@ name].settings.xml.
 - **Arguments**: Optional. An array of arguments to be sent to the program being started. Each argument will be subject to pattern expansion and if the result contains spaces, it will be enclosed in double quotation marks when the command line is built.
 - **Show output file**: Optional. If set, and if the Output file property has been specified, and if the execution of the external program is successful (exit code 0), the output file will be shown in the systems standard program for that file type (as if it was double-clicked in the windows explorer).
 - **Do not wait for Application**: If analysis includes this property, QTM does not wait for external program to finish the processing. If property does not exit, to continue with subsequent analyses, external program must be closed manually (> QTM 2019.1).
-- **Measurements:** Used to select which measurements to export when using ``Export Measurements``. See [Overview of analyses](#overview-of-analyses)
-- **Exclude:** See [Overview of analyses](#overview-of-analyses)
+- **Measurements**: Optional. Used to select which measurements to export when using ``Export Measurements``. See [Overview of analyses](#overview-of-analyses)
+- **Exclude**: Optional. See [Overview of analyses](#overview-of-analyses)
 
 Example:
 ```
@@ -301,7 +301,7 @@ Analyses:
 >Note: this analysis type requires the "Project Automation Framework" developer license. Instead, you can use the External program analysis type and specify Visual3D as the external program. An example for this can be found at:
 https://github.com/qualisys/paf-visual3d-example.
 
-> Note: Visual3D analysis can't be used as a parent sessions level analysis.
+> Note: Visual3D analysis can't be used in parent session mode.
 
 The Visual3D analysis has the following properties:
 - **Pipeline template**: The name of a template file in the Templates directory. This file will be instantiated and used as the pipeline script in visual 3d. This property is mandatory.
@@ -368,12 +368,12 @@ This analysis will instantiate a single PHP template and put the result in the w
 properties:
 - **Template:** Required. The name of the input file. If this name contains any path delimiter tokens, it will be considered to be relative to the project directory, otherwise QTM will assume that the input file is placed in the templates folder.
 - **Output file**: Optional name of the output file. The output file is always put in the current working directory. If this option is not supplied, the name of the template file will be used. If the template file name ends with the .php extension, it will be remove from output filename.
-- **Measurements:** Selected measurements to be passed as arguments to the PHP script. See: [Overview of analyses](#overview-of-analyses)
-- **Exclude:** See [Overview of analyses](#overview-of-analyses)
+- **Measurements**: Optional. Selected measurements to be passed as arguments to the PHP script. See: [Overview of analyses](#overview-of-analyses)
+- **Exclude**: Optional. See [Overview of analyses](#overview-of-analyses)
 
 #### Create skeleton (Introduced in QTM 2021.2)
 This analysis creates skeletons for the specified file provided that the correct marker names and prefixes are used (see the marker set guides in QTM > Skeleton for more information). It has the followng properties:
-- **Measurements:** Specifies the file to use for creating the skeletons. If multiple files are detected, only one is used.
+- **Measurements**: Required. Specifies the file to use for creating the skeletons. If multiple files are detected, only one is used.
 
     Relative paths may be used for sharing the same calibration measurements between subsessions. 
     Example: ```Measurements: ..\Static\Static*```
@@ -384,8 +384,8 @@ This analysis creates skeletons for the specified file provided that the correct
 
 #### Solve skeleton (Introduced in QTM 2021.2)
 This analysis solves skeletons for the specified files provided that the skeletons already exist  and that the correct marker names and prefixes are used (see the marker set guides in QTM > Skeleton for more information). It has the following properties:
-- **Measurements:** Selected measurements for which to solve skeletons. See [Overview of analyses](#overview-of-analyses)
-- **Exclude:** See [Overview of analyses](#overview-of-analyses)
+- **Measurements**: Optional. Selected measurements for which to solve skeletons. See [Overview of analyses](#overview-of-analyses)
+- **Exclude**: Optional. See [Overview of analyses](#overview-of-analyses)
 
 Example 1:
 ```

--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ name].settings.xml.
 - **Arguments**: Optional. An array of arguments to be sent to the program being started. Each argument will be subject to pattern expansion and if the result contains spaces, it will be enclosed in double quotation marks when the command line is built.
 - **Show output file**: Optional. If set, and if the Output file property has been specified, and if the execution of the external program is successful (exit code 0), the output file will be shown in the systems standard program for that file type (as if it was double-clicked in the windows explorer).
 - **Do not wait for Application**: If analysis includes this property, QTM does not wait for external program to finish the processing. If property does not exit, to continue with subsequent analyses, external program must be closed manually (> QTM 2019.1).
-- **Measurements:** See: [Overview of analyses]
-- **Exclude:** See: [Overview of analyses]
+- **Measurements:** See [Overview of analyses](#overview-of-analyses)
+- **Exclude:** See [Overview of analyses](#overview-of-analyses)
 
 Example:
 ```
@@ -327,8 +327,8 @@ This analysis will instantiate a single PHP template and put the result in the w
 properties:
 - **Template:** Required. The name of the input file. If this name contains any path delimiter tokens, it will be considered to be relative to the project directory, otherwise QTM will assume that the input file is placed in the templates folder.
 - **Output file**: Optional name of the output file. The output file is always put in the current working directory. If this option is not supplied, the name of the template file will be used. If the template file name ends with the .php extension, it will be remove from output filename.
-- **Measurements:** See: [Overview of analyses]
-- **Exclude:** See: [Overview of analyses]
+- **Measurements:** See [Overview of analyses](#overview-of-analyses)
+- **Exclude:** See [Overview of analyses](#overview-of-analyses)
 
 #### Create skeleton (Introduced in QTM 2021.2)
 This analysis creates skeletons for the specified file provided that the correct marker names and prefixes are used (see the marker set guides in QTM > Skeleton for more information). It has the followng properties:
@@ -342,8 +342,8 @@ This analysis creates skeletons for the specified file provided that the correct
 
 #### Solve skeleton (Introduced in QTM 2021.2)
 This analysis solves skeletons for the specified files provided that the skeletons already exist  and that the correct marker names and prefixes are used (see the marker set guides in QTM > Skeleton for more information). It has the following properties:
-- **Measurements:** See: [Overview of analyses]
-- **Exclude:** See: [Overview of analyses]
+- **Measurements:** See [Overview of analyses](#overview-of-analyses)
+- **Exclude:** See [Overview of analyses](#overview-of-analyses)
 
 Example 1:
 ```

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Decide if you need.
 Example:
 ```
 Types:
-  Subject:
+  Subject:  
     ...
   Date:
     ...
@@ -251,7 +251,6 @@ Each analysis definition is a map that has some properties common to all analysi
 >
 - **Prerequisites**: A sequence of measurement type names and analysis names that has to be completed before this analysis can be run. Measurement types are considered complete for the current session when the user has made at least the number of measurements given by that measurement type’s Minimum count field. Analyses are considered complete when the file denoted by the Output file field exists.
 > Note: Prerequisites can't be used when executing parent session level analyses.
-
 - **Output file**: The name of a file that is created when this analysis is run. QTM uses this to check if the analysis has been completed. It is also used to issue a warning if this file has been changed since the analysis was last run for the current session. This property can contain patterns.
 
 - **Exclude:** Optional. A string or list of strings to specify the file names to exclude. The string patterns available are the same as for the ``Measurements`` field.

--- a/README.md
+++ b/README.md
@@ -132,10 +132,6 @@ These modes also affects if certain analyses and analysis features are a availab
 
 Selecting which mode to use is done by creating the session structure in the PAF YAML file. 
 
-Decide if you need.
-   - Session -> Measurement (``Session level analysis``)
-   - Session -> Subsession -> Measurement (``Parent sessions level analysis``)
-
 Example:
 ```
 Types:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ PAF type definitions are organized into classes. Classes are currently not used 
 When type name references are required in the PAF file, two forms are applicable. Either a class name can be given, which will include all types of that class or a ClassName.TypeName form can be used to reference a single type only.
 
 ## Analysis Modes
-An analysis is one or a series of operations which uses QTM to generate output data. It can use QTM measurements in the data tree to do calculations and export files. Exactly what the analysis does and which files it uses is defined in the PAF YAML file. See [Overview of analyses](#overview-of-analyses) for more information about analyses.
+An analysis is one or more operations which uses QTM to generate output data. It can use QTM measurements in the data tree to do calculations and export files. Exactly what the analysis does and which files it uses is defined in the PAF YAML file. See [Overview of analyses](#overview-of-analyses) for more information about analyses.
 
 Two modes of execution of analyses are supported, these are defined by their relation to their measurement files. 
 
@@ -125,10 +125,10 @@ Two modes of execution of analyses are supported, these are defined by their rel
     In this mode measurement files are placed directly under the folder the analysis.
 
 2. ``Parent sessions level analysis``
-    In this mode the analsysis is executed on a folder that does not directly contain measurement files. Instead it contains Subsession folders, which in turn contain the measurement files.
+    In this mode the analysis is executed on a folder that does not directly contain measurement files. Instead it contains Subsession folders, which in turn contain the measurement files.
     This is useful when you need to create bulk analyses on a large amount of files.
 
-These modes also affects if certain analyses and analysis features are a available. This is described per- analysis.
+These modes determine if certain analyses and analysis features are a available. This is described per- analysis.
 
 Selecting which mode to use is done by creating the session structure in the PAF YAML file. 
 
@@ -253,7 +253,7 @@ Each analysis definition is a map that has some properties common to all analysi
 
   Default:
 
-  If he exclude field has not been defined no extra exclusions will be applied.
+  If the exclude field has not been defined no extra exclusions will be applied.
 
 - **Measurements:** Optional. A list of strings which specify the measurement files to use. Only measurements that are marked as used in the PAF pane are affected. Measurements found by the ``Exclude`` filter are also not used. It's specified per analysis if the ``Measurements`` field is utilized for that particular analysis. 
     Accepts special characters patterns such as

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Each analysis definition is a map that has some properties common to all analysi
 > Note: Prerequisites can't be used when executing parent session level analyses.
 
 - **Output file**: The name of a file that is created when this analysis is run. QTM uses this to check if the analysis has been completed. It is also used to issue a warning if this file has been changed since the analysis was last run for the current session. This property can contain patterns.
+
 - **Exclude:** Optional. A string or list of strings to specify the file names to exclude. The string patterns available are the same as for the ``Measurements`` field.
 
   Default:
@@ -242,7 +243,7 @@ name].settings.xml.
 - **Arguments**: Optional. An array of arguments to be sent to the program being started. Each argument will be subject to pattern expansion and if the result contains spaces, it will be enclosed in double quotation marks when the command line is built.
 - **Show output file**: Optional. If set, and if the Output file property has been specified, and if the execution of the external program is successful (exit code 0), the output file will be shown in the systems standard program for that file type (as if it was double-clicked in the windows explorer).
 - **Do not wait for Application**: If analysis includes this property, QTM does not wait for external program to finish the processing. If property does not exit, to continue with subsequent analyses, external program must be closed manually (> QTM 2019.1).
-- **Measurements:** See [Overview of analyses](#overview-of-analyses)
+- **Measurements:** Used to select which measurements to export when using ``Export Measurements``. See [Overview of analyses](#overview-of-analyses)
 - **Exclude:** See [Overview of analyses](#overview-of-analyses)
 
 Example:
@@ -327,7 +328,7 @@ This analysis will instantiate a single PHP template and put the result in the w
 properties:
 - **Template:** Required. The name of the input file. If this name contains any path delimiter tokens, it will be considered to be relative to the project directory, otherwise QTM will assume that the input file is placed in the templates folder.
 - **Output file**: Optional name of the output file. The output file is always put in the current working directory. If this option is not supplied, the name of the template file will be used. If the template file name ends with the .php extension, it will be remove from output filename.
-- **Measurements:** See [Overview of analyses](#overview-of-analyses)
+- **Measurements:** Selected measurements to be passed as arguments to the PHP script. See: [Overview of analyses](#overview-of-analyses)
 - **Exclude:** See [Overview of analyses](#overview-of-analyses)
 
 #### Create skeleton (Introduced in QTM 2021.2)
@@ -342,7 +343,7 @@ This analysis creates skeletons for the specified file provided that the correct
 
 #### Solve skeleton (Introduced in QTM 2021.2)
 This analysis solves skeletons for the specified files provided that the skeletons already exist  and that the correct marker names and prefixes are used (see the marker set guides in QTM > Skeleton for more information). It has the following properties:
-- **Measurements:** See [Overview of analyses](#overview-of-analyses)
+- **Measurements:** Selected measurements for which to solve skeletons. See [Overview of analyses](#overview-of-analyses)
 - **Exclude:** See [Overview of analyses](#overview-of-analyses)
 
 Example 1:

--- a/README.md
+++ b/README.md
@@ -205,7 +205,31 @@ Each analysis definition is a map that has some properties common to all analysi
 >Note: only External program and Compound are available to all users. Other types require the Project Automation Framework developer license which is used for internal Qualisys development and by development partners.
 >
 - **Prerequisites**: A sequence of measurement type names and analysis names that has to be completed before this analysis can be run. Measurement types are considered complete for the current session when the user has made at least the number of measurements given by that measurement type’s Minimum count field. Analyses are considered complete when the file denoted by the Output file field exists.
+> Note: Prerequisites can't be used when executing parent session level analyses.
+
 - **Output file**: The name of a file that is created when this analysis is run. QTM uses this to check if the analysis has been completed. It is also used to issue a warning if this file has been changed since the analysis was last run for the current session. This property can contain patterns.
+- **Exclude:** Optional. A string or list of strings to specify the file names to exclude. The string patterns available are the same as for the ``Measurements`` field.
+
+  Default:
+
+  If he exclude field has not been defined no extra exclusions will be applied.
+
+- **Measurements:** Optional. A list of strings which specify the measurement files to use. Only measurements that are marked as used in the PAF pane are affected. Measurements found by the ``Exclude`` filter are also not used. It's specified per analysis if the ``Measurements`` field is utilized for that particular analysis. 
+    Accepts special characters patterns such as
+    - ``..`` Parent dir 
+    -  ``*`` Wild card file or directory name. Using ``**`` to traverse multiple levels of subfolders is not supported.
+
+    Default:
+
+    If the Measurements field has not been defined it's set to the default value: ``'*.qtm' ``
+
+    Example:
+    ```
+    Measurements: 
+      - '*.qtm'
+      - "..\\Folder\\SubFolder*\\*File.qtm"
+      - '*\*'
+    ```
 
 #### External program
 This analysis runs an arbitrary external program supplying a command line defined by the PAF file. There is optional support for exporting measurements as well as instantiating php template files before running the program.
@@ -213,6 +237,7 @@ This analysis runs an arbitrary external program supplying a command line define
 It has the following properties:
 -  **Program display name**: Required. The name to be displayed in the directories tab in project options where the user will have to locate the external executable. NB: Because this path varies between computers rather than between projects, it is not stored in the project, but in computer-global settings file. Several analyses in different projects may share the same Program display name and QTM will automatically use the same executable path for all of them.
 - **Export session**: Optional. If present, the metadata of the session, all its ancestors and the measurements are exported into a file called session.xml.
+> Note: Export session can't be used when executing parent session level analyses.
 - **Export measurements**: Optional. A single string or an array containing any combination of the following values: “TSV”, “C3D”, “MAT”. Will make QTM export all the selected measurements to the corresponding formats before running the external program. Use “xml settings” to export a file with measurement settings (e.g. capture start time and analog channel names). The file will be named [file
 name].settings.xml.
 - **Template files**: Optional. A single string or an array containing names of files in the template directory. Each file will be run through the PHP engine and the result written to a file with the same name in the session directory. Standard Windows wildcards are supported, but note that if the asterisk is used to match a part of the filename, the pattern must be enclosed in single quotation marks to make sure it is not parsed as a YAML alias.
@@ -220,6 +245,8 @@ name].settings.xml.
 - **Arguments**: Optional. An array of arguments to be sent to the program being started. Each argument will be subject to pattern expansion and if the result contains spaces, it will be enclosed in double quotation marks when the command line is built.
 - **Show output file**: Optional. If set, and if the Output file property has been specified, and if the execution of the external program is successful (exit code 0), the output file will be shown in the systems standard program for that file type (as if it was double-clicked in the windows explorer).
 - **Do not wait for Application**: If analysis includes this property, QTM does not wait for external program to finish the processing. If property does not exit, to continue with subsequent analyses, external program must be closed manually (> QTM 2019.1).
+- **Measurements:** See: [Overview of analyses]
+- **Exclude:** See: [Overview of analyses]
 
 Example:
 ```
@@ -235,7 +262,9 @@ Analyses:
 #### Visual3D analysis
 >Note: this analysis type requires the "Project Automation Framework" developer license. Instead, you can use the External program analysis type and specify Visual3D as the external program. An example for this can be found at:
 https://github.com/qualisys/paf-visual3d-example.
->
+
+> Note: Visual3D analysis can't be used as a parent sessions level analysis.
+
 The Visual3D analysis has the following properties:
 - **Pipeline template**: The name of a template file in the Templates directory. This file will be instantiated and used as the pipeline script in visual 3d. This property is mandatory.
 - **Do not wait for Visual3D**: If analysis includes this property, QTM does not wait for Visual3D to finish the processing. If property does not exit, to continue with subsequent analyses, Visual3D must be closed manually or Exit_Workspace; command has to be added to the very end of Visual3D script.
@@ -301,6 +330,8 @@ This analysis will instantiate a single PHP template and put the result in the w
 properties:
 - **Template:** Required. The name of the input file. If this name contains any path delimiter tokens, it will be considered to be relative to the project directory, otherwise QTM will assume that the input file is placed in the templates folder.
 - **Output file**: Optional name of the output file. The output file is always put in the current working directory. If this option is not supplied, the name of the template file will be used. If the template file name ends with the .php extension, it will be remove from output filename.
+- **Measurements:** See: [Overview of analyses]
+- **Exclude:** See: [Overview of analyses]
 
 #### Create skeleton (Introduced in QTM 2021.2)
 This analysis creates skeletons for the specified file provided that the correct marker names and prefixes are used (see the marker set guides in QTM > Skeleton for more information). It has the followng properties:
@@ -314,8 +345,8 @@ This analysis creates skeletons for the specified file provided that the correct
 
 #### Solve skeleton (Introduced in QTM 2021.2)
 This analysis solves skeletons for the specified files provided that the skeletons already exist  and that the correct marker names and prefixes are used (see the marker set guides in QTM > Skeleton for more information). It has the following properties:
-- **Measurements:** Required. A string or list of strings to specify the file names to solve the skeletons. Wildcard can be used in the name to specify multiple files at once. To specify all measurements, simply use the wildcard character. Only measurements that are marked as used in the PAF pane will be affected.
-- **Exclude:** Optional. A string or list of strings to specify the file names to exclude. Wildcard can be used in the name to specify multiple files at once.  Only measurements that are marked as used in the PAF pane will be affected.
+- **Measurements:** See: [Overview of analyses]
+- **Exclude:** See: [Overview of analyses]
 
 Example 1:
 ```


### PR DESCRIPTION
QTM has added support for declaring an analysis list on parent sessions.
Executing analyses from different places in the data tree behaves slightly different, or is not supported at all depending on the analysis and feature. This PR adds a distinction for two different modes and describes how to use them.

In order to be able to select files in an easy way from the parent session level, QTM has added support for the ``Measurements`` and ``Exclude`` field for more analyses. By default ``Exclude`` is empty and ``Measurements`` is set to "*.qtm" which makes analyses work as before for session level analyses.

The `Create skeleton` has updated the field name `Calibration measurement` to `Measurements`. Compatibility with the old name remains.
