### PR TITLE
Moved display name to the analysis level

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Each analysis definition is a map that has some properties common to all analysi
 
   If the exclude field has not been defined no extra exclusions will be applied.
 
-- **Display name**: Optional. If provided, this is the name displayed drop-down list under "Start Processing". Otherwise the name in the defined by the analysis YAML node.
+- **Display name**: Optional. If provided, this is the name displayed in the drop-down list under "Start Processing". Otherwise, the name defined by the analysis YAML node will be used.
 
 - **Measurements**: Optional. A list of strings which specify the measurement files to use. Only measurements that are marked as used in the PAF pane are affected. Measurements found by the ``Exclude`` filter are also not used. It's specified per analysis if the ``Measurements`` field is utilized for that particular analysis. 
     Accepts special characters patterns such as

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ Each analysis definition is a map that has some properties common to all analysi
 
   If the exclude field has not been defined no extra exclusions will be applied.
 
+- **Display name**: Optional. If provided, this is the name displayed drop-down list under "Start Processing". Otherwise the name in the defined by the analysis YAML node.
+
 - **Measurements**: Optional. A list of strings which specify the measurement files to use. Only measurements that are marked as used in the PAF pane are affected. Measurements found by the ``Exclude`` filter are also not used. It's specified per analysis if the ``Measurements`` field is utilized for that particular analysis. 
     Accepts special characters patterns such as
     - ``..`` Parent dir 
@@ -351,7 +353,6 @@ The report analysis runs the external ReportGenerator program located in the tem
 #### Compound
 This analysis combines several other analyses into consecutive steps. By default subsequent analysis is started after previous one has finished unless **Do not wait for Visual3D** or **Do not wait for Application** property is set. It has the following properties:
 - **Compound**: Required. An array of analysis steps.
-- **Display name**: Optional. If provided, this is the name displayed in QTM. If omitted, the name of the Analysis/Compound will be used ("Analysis and Export" in the example below).
 - **Prerequisites**: Optional. See above.
 
 ```

--- a/README.md
+++ b/README.md
@@ -256,6 +256,14 @@ Each analysis definition is a map that has some properties common to all analysi
   If the exclude field has not been defined no extra exclusions will be applied.
 
 - **Display name**: Optional. If provided, this is the name displayed in the drop-down list under "Start Processing". Otherwise, the name defined by the analysis YAML node will be used.
+  Example:
+  ```
+    Analysis and Export:
+      Type: Compound
+      Display name: A and E
+      Components: [Processing, Export]
+  ```
+  ![Display_name_example](assets/images/Display_name_example.png)
 
 - **Measurements**: Optional. A list of strings which specify the measurement files to use. Only measurements that are marked as used in the PAF pane are affected. Measurements found by the ``Exclude`` filter are also not used. It's specified per analysis if the ``Measurements`` field is utilized for that particular analysis. 
     Accepts special characters patterns such as
@@ -354,15 +362,6 @@ The report analysis runs the external ReportGenerator program located in the tem
 This analysis combines several other analyses into consecutive steps. By default subsequent analysis is started after previous one has finished unless **Do not wait for Visual3D** or **Do not wait for Application** property is set. It has the following properties:
 - **Compound**: Required. An array of analysis steps.
 - **Prerequisites**: Optional. See above.
-
-```
-  Analysis and Export:
-    Type: Compound
-    Display name: A and E
-    Components: [Processing, Export]
-```
-
-![Display_name_example](assets/images/Display_name_example.png)
 
 #### Instantiate template
 This analysis will instantiate a single PHP template and put the result in the working directory. It has the following


### PR DESCRIPTION
Since the implementation allows any analysis to use the `Display name` field. It needs to be reflected in the documentation.

This PR moves `Display name` from the `Compound` analysis into the general analysis segment.